### PR TITLE
change hardcoded path in prefix for CRAFT_STAGE

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -136,7 +136,7 @@ parts:
     override-stage: |
       craftctl default
       for PCFILE in "libebook-contacts-1.2.pc" "libedataserver-1.2.pc" "libedataserverui4-1.0.pc" "camel-1.2.pc" "evolution-data-server-1.2.pc" "libebackend-1.2.pc" "libecal-2.0.pc" "libebook-1.2.pc" "libedata-cal-2.0.pc" "libedata-book-1.2.pc"; do
-        sed -i "s#prefix=/root/stage/usr#prefix=/root/stage#g" $CRAFT_STAGE/usr/lib/pkgconfig/$PCFILE
+        sed -i "s#prefix=$CRAFT_STAGE/usr#prefix=$CRAFT_STAGE#g" $CRAFT_STAGE/usr/lib/pkgconfig/$PCFILE
         sed -i "s#includedir=/usr/include#includedir=\${prefix}/usr/include#g" $CRAFT_STAGE/usr/lib/pkgconfig/$PCFILE
         sed -i "s#libdir=/usr/lib#libdir=\${prefix}/usr/lib#g" $CRAFT_STAGE/usr/lib/pkgconfig/$PCFILE
         sed -i "s#datarootdir=/usr/lib#datarootdir=\${prefix}/usr/lib#g" $CRAFT_STAGE/usr/lib/pkgconfig/$PCFILE


### PR DESCRIPTION
changing path so launchpad build finds missing header files
this is in lieu of #6 which contains a python script now being merged into [sergio-costas/snap-build-tools](https://github.com/sergio-costas/snap-build-tools)

